### PR TITLE
Add abbreviated operation flags, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This is an implementation of popular web comic [xkcd](https://xkcd.com/)'s so-ca
 
 ## Requirement
 
-.NET 9 runtime
+- .NET 9 runtime
 
 ## Usage
 
 ```
-dotnet run -- [--encode|--decode|--test] input1 optionalInput2
+dotnet run -- [--encode|-e|--decode|-d|--test|-t] input1 optionalInput2
 ```
 
 > [!NOTE]
@@ -34,7 +34,7 @@ A̰ÁĂĂÅ
 ```
 
 ```sh
-$ dotnet run -- --encode "hello" "this is kinda neat"
+$ dotnet run -- -e "hello" "this is kinda neat"
 A̰ÁĂĂÅ
 ĀA̰ẢÃ ẢÃ ẠẢÂA̠A ÂÁAĀ
 ```

--- a/src/ArgValidation.fs
+++ b/src/ArgValidation.fs
@@ -29,7 +29,7 @@ let flagSummary =
         |> groupByValues
         |> toNestedPairs ", " "; "
 
-    $"""Supported flags: %s{String.Join(", ", flags)}"""
+    $"""Supported flags: %s{String.Join(", ", flags)}."""
 
 let private validateArgCount (args: string array) =
     let instructions = $"Supply an operation flag and at least one string to convert.\n%s{flagSummary}"
@@ -42,19 +42,14 @@ let private validateArgCount (args: string array) =
 let private validateFlag (flag: string) =
     if supportedFlags.ContainsKey flag
     then Ok supportedFlags[flag]
-    else Error $"Unsupported flag \"%s{flag}\". %s{flagSummary}."
-
-let private validateInputs (inputs: string array) =
-    if inputs.Length = 0
-    then Error "No inputs to convert were passed."
-    else Ok (inputs |> Array.map _.ToUpperInvariant())
+    else Error $"Unsupported flag \"%s{flag}\". %s{flagSummary}"
 
 let validate (rawArgs: string array) =
     result {
         let! args = validateArgCount rawArgs
         let flag, inputs = args[0], args[1..]
         let! operation = validateFlag flag
-        let! inputs' = validateInputs inputs
-        return { Operation = operation; Inputs = inputs' }
+        return { Operation = operation
+                 Inputs = inputs |> Array.map _.ToUpperInvariant() }
     }
 

--- a/src/ArgValidation.fs
+++ b/src/ArgValidation.fs
@@ -12,16 +12,16 @@ type ValidatedArgs =
       Inputs: string array }
 
 let supportedFlags =
-    // A dictionary, currently, preserves the order of added items,
+    // Dictionaries, as currently implemented, preserve the order of added items,
     // whereas F#'s native Map does not.
-    let od = Dictionary<string, Operation>()
-    od.Add("--encode", Encode)
-    od.Add("-e", Encode)
-    od.Add("--decode", Decode)
-    od.Add("-d", Decode)
-    od.Add("--test", Test)
-    od.Add("-t", Test)
-    od
+    let flags = Dictionary<string, Operation>()
+    flags.Add("--encode", Encode)
+    flags.Add("-e", Encode)
+    flags.Add("--decode", Decode)
+    flags.Add("-d", Decode)
+    flags.Add("--test", Test)
+    flags.Add("-t", Test)
+    flags
 
 let flagSummary =
     let flags =

--- a/src/ArgValidation.fs
+++ b/src/ArgValidation.fs
@@ -27,8 +27,7 @@ let flagSummary =
     let flags =
         supportedFlags
         |> groupByValues
-        |> Seq.map (fun opGroup -> String.Join(", ", snd opGroup))
-        |> String.concat "; "
+        |> toNestedPairs ", " "; "
 
     $"""Supported flags: %s{String.Join(", ", flags)}"""
 

--- a/src/ArgValidation.fs
+++ b/src/ArgValidation.fs
@@ -27,7 +27,7 @@ let flagSummary =
     let flags =
         supportedFlags
         |> groupByValues
-        |> toNestedPairs ", " "; "
+        |> toNestedPairs ", " "; " // Formatting sample: "--encode, -e; --decode, -d"
 
     $"""Supported flags: %s{String.Join(", ", flags)}."""
 

--- a/src/Utilities.fs
+++ b/src/Utilities.fs
@@ -1,6 +1,7 @@
 module Utilities
 
 open System
+open System.Collections.Generic
 
 let flip map : Map<'a, 'b> =
     Map.fold (fun acc k v -> Map.add v k acc) Map.empty map
@@ -12,3 +13,10 @@ let merge secondary primary : Map<'a, 'b> =
 let caseInsensitiveEquals (x: string) (y: string) : bool =
     x.Equals(y, StringComparison.InvariantCultureIgnoreCase)
 
+let groupByValues (items: KeyValuePair<'b, 'a> seq) : seq<'a * 'b list> =
+    items
+    |> Seq.map (fun (KeyValue(k, vs)) -> vs, k)
+    |> Seq.groupBy fst
+    |> Seq.map (fun (op, pairs) ->
+        let keys = pairs |> Seq.map snd |> Seq.toList
+        op, keys)

--- a/src/Utilities.fs
+++ b/src/Utilities.fs
@@ -13,10 +13,17 @@ let merge secondary primary : Map<'a, 'b> =
 let caseInsensitiveEquals (x: string) (y: string) : bool =
     x.Equals(y, StringComparison.InvariantCultureIgnoreCase)
 
-let groupByValues (items: KeyValuePair<'b, 'a> seq) : seq<'a * 'b list> =
+let groupByValues (items: KeyValuePair<'b, 'a> seq) : ('a * 'b seq) seq =
     items
-    |> Seq.map (fun (KeyValue(k, vs)) -> vs, k)
-    |> Seq.groupBy fst
-    |> Seq.map (fun (op, pairs) ->
-        let keys = pairs |> Seq.map snd |> Seq.toList
-        op, keys)
+    |> Seq.groupBy _.Value
+    |> Seq.map (fun (groupValue, groupItems) ->
+        let keys = groupItems |> Seq.map _.Key
+        groupValue, keys)
+
+let toNestedPairs (innerSeparator: string)
+                  (outerSeparator: string)
+                  (items: ('a * 'b seq) seq)
+                  : string =
+    items
+    |> Seq.map (fun (_, v) -> String.Join(innerSeparator, v))
+    |> String.concat outerSeparator

--- a/src/Utilities.fs
+++ b/src/Utilities.fs
@@ -3,27 +3,29 @@ module Utilities
 open System
 open System.Collections.Generic
 
-let flip map : Map<'a, 'b> =
-    Map.fold (fun acc k v -> Map.add v k acc) Map.empty map
+let flip (map: Map<'k, 'v>) : Map<'v, 'k> =
+    Map.fold
+        (fun acc k v -> Map.add v k acc)
+        Map.empty map
 
-// Merge two maps with the values of the 'primary' one taking precedence.
-let merge secondary primary : Map<'a, 'b> =
-    Map.fold (fun acc k v -> Map.add k v acc) secondary primary
+let merge secondary primary : Map<'k, 'v> =
+    Map.fold
+        (fun acc k v -> Map.add k v acc)
+        secondary
+        primary // Takes precedence, overwriting as needed.
 
-let caseInsensitiveEquals (x: string) (y: string) : bool =
-    x.Equals(y, StringComparison.InvariantCultureIgnoreCase)
+let caseInsensitiveEquals (first: string) (second: string) : bool =
+    first.Equals(second, StringComparison.InvariantCultureIgnoreCase)
 
-let groupByValues (items: KeyValuePair<'b, 'a> seq) : ('a * 'b seq) seq =
-    items
+let groupByValues (pairs: KeyValuePair<'k, 'v> seq) : ('v * 'k seq) seq =
+    pairs
     |> Seq.groupBy _.Value
-    |> Seq.map (fun (groupValue, groupItems) ->
-        let keys = groupItems |> Seq.map _.Key
-        groupValue, keys)
+    |> Seq.map (fun (v, pairs) -> v, pairs |> Seq.map _.Key)
 
 let toNestedPairs (innerSeparator: string)
                   (outerSeparator: string)
-                  (items: ('a * 'b seq) seq)
+                  (tuples: ('k * string seq) seq)
                   : string =
-    items
-    |> Seq.map (fun (_, v) -> String.Join(innerSeparator, v))
+    tuples
+    |> Seq.map (fun (_, vs) -> vs |> String.concat innerSeparator)
     |> String.concat outerSeparator

--- a/src/Utilities.fs
+++ b/src/Utilities.fs
@@ -6,7 +6,8 @@ open System.Collections.Generic
 let flip (map: Map<'k, 'v>) : Map<'v, 'k> =
     Map.fold
         (fun acc k v -> Map.add v k acc)
-        Map.empty map
+        Map.empty
+        map
 
 let merge secondary primary : Map<'k, 'v> =
     Map.fold


### PR DESCRIPTION
1. Add abbreviated operation flags (i.e., `-e` for `--encode`, etc.)
2. Use a `Dictionary` to preserve the order of operation flags in the program instructions
3. Remove superfluous validation